### PR TITLE
Cancel internal context before closing websocket on shutdown

### DIFF
--- a/botkit.go
+++ b/botkit.go
@@ -182,8 +182,9 @@ func NewBot(cfg *config.BotConfig) (*Bot, error) {
 		cfg:        cfg,
 		LogBackend: logBackend,
 
-		wsc: wsc,
-		ctx: ctx,
+		wsc:       wsc,
+		ctx:       ctx,
+		cancelCtx: cancel,
 
 		gcChan:     cfg.GCChan,
 		gcLog:      cfg.GCLog,

--- a/interface.go
+++ b/interface.go
@@ -19,8 +19,9 @@ type Bot struct {
 
 	LogBackend *logging.LogBackend
 
-	wsc *jsonrpc.WSClient
-	ctx context.Context
+	wsc       *jsonrpc.WSClient
+	ctx       context.Context
+	cancelCtx context.CancelFunc
 
 	wl     map[string]int64
 	wlFile string
@@ -70,6 +71,9 @@ func (g GCs) Swap(a, b int) {
 }
 
 func (b *Bot) Close() error {
+	if b.cancelCtx != nil {
+		b.cancelCtx()
+	}
 	if b.LogBackend != nil {
 		err := b.LogBackend.Close()
 		if err != nil {


### PR DESCRIPTION
Store the context cancel func in the Bot struct and call it in Close() before closing the websocket connection. This allows the RPC readLoop to observe context cancellation and exit cleanly instead of logging an unexpected "use of closed network connection" error.

closes #1 